### PR TITLE
FirstPage: fix "About" font size

### DIFF
--- a/qml/pages/FirstPage.qml
+++ b/qml/pages/FirstPage.qml
@@ -122,7 +122,7 @@ BasePage {
                     id: infoButton
                     text: qsTr("About")
                     onClicked: instantiatePage(Qt.resolvedUrl("InfoPage.qml"))
-                    font.pixelSize: FontUtils.sizeToPixels("large")
+                    font.pixelSize: settingsButton.font.pixelSize
 
                     LuneOSButton.mainColor: LuneOSButton.blueColor
                 }


### PR DESCRIPTION
This looks like a bug in Qt, but I can't see where exactly.

Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>